### PR TITLE
[fix](item-sliding): Remove class item-sliding-closing on close transition

### DIFF
--- a/core/src/components/item-sliding/item-sliding.tsx
+++ b/core/src/components/item-sliding/item-sliding.tsx
@@ -407,15 +407,16 @@ export class ItemSliding implements ComponentInterface {
   }
 
   private setOpenAmount(openAmount: number, isFinal: boolean) {
+    const { el } = this;
+
     if (this.tmr !== undefined) {
       clearTimeout(this.tmr);
+      el.classList.remove('item-sliding-closing');
       this.tmr = undefined;
     }
     if (!this.item) {
       return;
     }
-
-    const { el } = this;
 
     const style = this.item.style;
     this.openAmount = openAmount;
@@ -457,6 +458,7 @@ export class ItemSliding implements ComponentInterface {
         if (this.gesture) {
           this.gesture.enable(!this.disabled);
         }
+
         el.classList.remove('item-sliding-closing');
       }, 600);
 

--- a/core/src/components/item-sliding/test/basic/index.html
+++ b/core/src/components/item-sliding/test/basic/index.html
@@ -162,6 +162,25 @@
               </ion-item-options>
             </ion-item-sliding>
           </div>
+
+          <div id="container">
+            <ion-list>
+              <ion-item-sliding id="item43">
+                <ion-item detail>
+                  <ion-label class="ion-text-wrap">
+                    <h2>RIGHT SIDE - Add element</h2>
+                    <p id="target-text">Add dynamic element as item-option</p>
+                  </ion-label>
+                </ion-item>
+
+                <ion-item-options id="target-element">
+                  <ion-item-option>ARCHIVE</ion-item-option>
+                </ion-item-options>
+              </ion-item-sliding>
+            </ion-list>
+
+            <ion-button id="add-element-btn" onclick="addElement()">Add element</ion-button>
+          </div>
         </ion-list>
 
         <script>
@@ -186,6 +205,45 @@
             if (itemEle) {
               itemEle.close();
             }
+          }
+
+          function changeTargetText() {
+            var item = document.getElementById('target-text');
+
+            var newTargetText = document.createTextNode(' - ADDED');
+            item.appendChild(newTargetText);
+          }
+
+          // Method to create the edge case reported on 28662
+          function addElement() {
+            var item = document.getElementById('item43');
+            var isAddedElement = item.querySelector('.element-added');
+
+            // If element exists, stop the function call
+            if (isAddedElement) {
+              return
+            }
+
+            // Define and create the elements to add on DOM
+            var itemSlidind = document.getElementById('target-element');
+            var newIonItemOption = document.createElement('ion-item-option');
+
+            var newIonItemOptionText = document.createTextNode('DELETE');
+
+            newIonItemOption.setAttribute('onclick', 'changeTargetText()');
+            newIonItemOption.setAttribute('color', 'danger');
+            newIonItemOption.setAttribute('id', 'element-added-delete');
+            newIonItemOption.classList.add('element-added');
+            newIonItemOption.appendChild(newIonItemOptionText);
+            itemSlidind.appendChild(newIonItemOption);
+
+            // Close the item-sliding to update the values
+            item.close();
+
+            // Make async call of the open method of item-sliding
+            setTimeout(function () {
+              item.open();
+            }, 0);
           }
         </script>
       </ion-content>

--- a/core/src/components/item-sliding/test/basic/item-sliding.e2e.ts
+++ b/core/src/components/item-sliding/test/basic/item-sliding.e2e.ts
@@ -68,6 +68,28 @@ configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, screenshot, co
       await expect(item).toHaveScreenshot(screenshot(`item-sliding-gesture`));
     });
 
+    test('the dynamic element should be clicked', async ({ page }) => {
+      await page.goto(`/src/components/item-sliding/test/basic`, config);
+      const item = page.locator('#item43');
+
+      // Scroll page in view and drag the item-sliding
+      await page.setIonViewport();
+      await dragElementBy(item, page, -150);
+      
+      // Trigger the button to add the dynamic content
+      const button = page.locator('#add-element-btn');
+      await button.click();
+
+      // Check if the element added is clicked
+      const elementAdded = page.locator('#element-added-delete')
+      await elementAdded.click();
+
+      await page.waitForChanges();
+
+      // item-sliding doesn't have an easy way to tell whether it's fully open so just screenshot it
+      await expect(item).toHaveScreenshot(screenshot(`dynamic-element-clicked`));
+    });
+
     test('should not scroll when the item-sliding is swiped', async ({ page, skip }) => {
       skip.browser('webkit', 'mouse.wheel is not available in WebKit');
 


### PR DESCRIPTION
### What is the current behavior?
When item sliding is opened we set specific transform amounts so the Item does not cover the Item Options. However, adding more Options does not cause this specific transform to update. As a result, newly added Options are still covered by the Item.

### What is the new behavior?
Now the `item-sliding` reacts to any option or element added as `item-option` in component.
![2024-01-26 12 17 58](https://github.com/bmarcelino-fe/ionic-framework/assets/25321845/a55b0276-245d-40dc-8bbe-38da6f0b317e)

### Does this introduce a breaking change?
- [ ] Yes
- [x] No